### PR TITLE
Fix for timestamp cast

### DIFF
--- a/lib/que/connection.rb
+++ b/lib/que/connection.rb
@@ -152,7 +152,12 @@ module Que
       },
 
       # Timestamp with time zone
-      1184 => Time.method(:parse),
+      1184 => -> (value) {
+        case value
+        when String then Time.parse(value)
+        else value
+        end
+      }
     }
 
     # JSON, JSONB


### PR DESCRIPTION
Not sure why, but postgres is returning an actual Time object, not a string, for the `run_at` column on job insert.

Ruby 2.6 / `pg` gem v1.1.4 / Postgres 10.4